### PR TITLE
Don't request release notes from closed PRs

### DIFF
--- a/internal/api/release_notes.go
+++ b/internal/api/release_notes.go
@@ -52,6 +52,10 @@ func handleReleaseNotesPR(c *Context, pr *github.PullRequestEvent) {
 		return
 	}
 
+	if pr.GetPullRequest().GetState() == "closed" {
+		return
+	}
+
 	org := pr.GetRepo().GetOwner().GetLogin()
 	repo := pr.GetRepo().GetName()
 	number := pr.GetNumber()


### PR DESCRIPTION
#### Summary
If a PR is already closed, chewbacca should not request release notes, as the PR might be older then our new process for release notes. Blocking new PRs from getting merged is enough to enforce that every new PR gets it's release notes.

#### Ticket Link
None

#### Release Note
```release-note
Don't request release notes from closed PRs

```
