### PR TITLE
Add labels on specific branch names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /build/chewbacca
+
+# Common used editors/IDEs
+.idea
+.vscode
+*.sw*

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,12 @@ govet:
 	$(GO) vet ./...
 	@echo Govet success
 
-## Builds and thats all :)
+## Builds and that's all :)
 .PHONY: dist
 dist:	build
 
 .PHONY: build
-build: ## Build the mattermost-cloud
+build: ## Build the Chewbacca
 	@echo Building Chewbacca
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build -gcflags all=-trimpath=$(PWD) -asmflags all=-trimpath=$(PWD) -a -installsuffix cgo -o build/chewbacca ./cmd
 

--- a/go.sum
+++ b/go.sum
@@ -60,7 +60,6 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -84,7 +83,6 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -133,8 +131,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
-github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -145,7 +141,6 @@ github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -168,7 +163,6 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
-golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 h1:XQyxROzUlZH+WIQwySDgnISgOivlhjIEwaQaJEJrrN0=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -177,7 +171,6 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 h1:rjwSpXsdiK0dV8/Naq3kAw9ymfAeJIyd0upUIElB+lI=
@@ -195,7 +188,6 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7 h1:HmbHVPwrPEKPGLAcHSrMe6+hqSUlvZU0rab6x5EXfGU=
 golang.org/x/sys v0.0.0-20191022100944-742c48ecaeb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -208,7 +200,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20181011042414-1f849cf54d09/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -14,6 +14,7 @@ type Actions interface {
 type GitHub interface {
 	ValidateSignature(receivedHash []string, bodyBuffer []byte) error
 	CreateComment(org, repo string, number int, comment string)
+	CreateLabel(org, repo string, label github.Label) error
 	AddLabels(org, repo string, number int, labels []string) error
 	RemoveLabel(org, repo string, number int, label string) error
 	GetIssueLabels(org, repo string, number int) ([]*github.Label, error)

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -13,7 +13,7 @@ type Actions interface {
 // GitHub describes the interface required to persist changes made via API requests.
 type GitHub interface {
 	ValidateSignature(receivedHash []string, bodyBuffer []byte) error
-	CreateComment(org, repo string, number int, comment string)
+	CreateComment(org, repo string, number int, comment string) error
 	CreateLabel(org, repo string, label github.Label) error
 	AddLabels(org, repo string, number int, labels []string) error
 	RemoveLabel(org, repo string, number int, label string) error

--- a/internal/api/github_webhook.go
+++ b/internal/api/github_webhook.go
@@ -75,7 +75,7 @@ func handleReceiveWebhook(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	default:
-		c.Logger.Info("other events not implemeted")
+		c.Logger.Info("other events not implemented")
 		w.WriteHeader(http.StatusNotImplemented)
 		return
 	}

--- a/internal/api/labels.go
+++ b/internal/api/labels.go
@@ -132,8 +132,8 @@ func handleCommentLabel(c *Context, e *github.IssueCommentEvent) {
 
 }
 
-func buildGhLabel(Name string, Description string, Color string) github.Label {
-	return github.Label{Name: &Name, Description: &Description, Color: &Color}
+func buildGhLabel(name string, description string, color string) github.Label {
+	return github.Label{Name: &name, Description: &description, Color: &color}
 }
 
 // Get Labels from Regexp matches

--- a/internal/api/labels.go
+++ b/internal/api/labels.go
@@ -132,6 +132,10 @@ func handleCommentLabel(c *Context, e *github.IssueCommentEvent) {
 
 }
 
+func buildGhLabel(Name string, Description string, Color string) github.Label {
+	return github.Label{Name: &Name, Description: &Description, Color: &Color}
+}
+
 // Get Labels from Regexp matches
 func getLabelsFromREMatches(matches [][]string) (labels []string) {
 	for _, match := range matches {

--- a/internal/api/release_notes.go
+++ b/internal/api/release_notes.go
@@ -73,20 +73,20 @@ func handleReleaseNotesPR(c *Context, pr *github.PullRequestEvent) {
 		repolabelsexisting.Insert(strings.ToLower(l.GetName()))
 	}
 	branchList := []string{
-		"feat",
-		"fix",
-		"test",
-		"chore",
-		"refactor",
+		"feat/",
+		"fix/",
+		"test/",
+		"chore/",
+		"refactor/",
 	}
 
 	branchToLabel := map[string]string{
-		"feat": "kind/feature",
-		"docs": "kind/documentation",
-		"fix": "kind/bug",
-		"test": "kind/testing",
-		"chore": "kind/chore",
-		"refactor": "kind/refactor",
+		"feat/": "kind/feature",
+		"docs/": "kind/documentation",
+		"fix/": "kind/bug",
+		"test/": "kind/testing",
+		"chore/": "kind/chore",
+		"refactor/": "kind/refactor",
 	}
 	labelsToColours := map[string]string{
 		"kind/feature": "c7def8",

--- a/internal/api/release_notes.go
+++ b/internal/api/release_notes.go
@@ -47,6 +47,7 @@ var (
 func handleReleaseNotesPR(c *Context, pr *github.PullRequestEvent) {
 	// Only consider events that edit the PR body or add a label
 	if pr.GetAction() != model.PullRequestActionOpened &&
+		pr.GetAction() != model.PullRequestActionReopened &&
 		pr.GetAction() != model.PullRequestActionEdited &&
 		pr.GetAction() != model.PullRequestActionLabeled {
 		return
@@ -60,13 +61,48 @@ func handleReleaseNotesPR(c *Context, pr *github.PullRequestEvent) {
 	repo := pr.GetRepo().GetName()
 	number := pr.GetNumber()
 	user := pr.GetPullRequest().GetUser().GetLogin()
+	branchName := pr.GetPullRequest().GetHead().GetRef()
+	repoLabels, err := c.GitHub.ListRepoLabels(org, repo)
+	if err != nil {
+		return
+	}
+
+	RepoLabelsExisting := sets.String{}
+	for _, l := range repoLabels {
+		RepoLabelsExisting.Insert(strings.ToLower(l.GetName()))
+	}
+	branchList := []string{
+		"feat",
+		"fix",
+		"test",
+		"chore",
+		"refactor",
+	}
+
+	branchToLabel := map[string]string{"feat": "kind/feature", "docs": "kind/documentation", "fix": "kind/bug", "test": "kind/testing", "chore": "kind/chore", "refactor": "kind/refactor"}
+	labelsToColours := map[string]string{"kind/feature": "c7def8", "kind/documentation": "c7def8", "kind/bug": "e11d21", "kind/chore": "c7def8", "kind/refactor": "c7def8", "kind/testing": "79D6D6"}
+	labelsToDescriptions := map[string]string{"kind/feature": "Categorizes issue or PR as related to a new feature.", "kind/documentation": "Categorizes issue or PR as related to documentation.", "kind/bug": "Categorizes issue or PR as related to a bug.", "kind/chore": "Categorizes issue or PR as related to updates that are not production code.", "kind/refactor": "Categorizes issue or PR as related to refactor of production code.", "kind/testing": "Categorizes issue or PR as related to addition or refactoring of tests."}
 
 	prInitLabels, err := c.GitHub.GetIssueLabels(org, repo, number)
 	if err != nil {
 		c.Logger.WithError(err).Errorf("failed to list labels on PR #%d", number)
 	}
-
+	var branchLabels []string
 	prLabels := utils.LabelsSet(prInitLabels)
+	for _, conventionSubstring := range branchList {
+
+		if strings.Contains(branchName, conventionSubstring) {
+			branchLabels = append(branchLabels, branchToLabel[conventionSubstring])
+			if !RepoLabelsExisting.Has(branchLabels[0]) {
+				c.GitHub.CreateLabel(org, repo, buildGhLabel(branchLabels[0], labelsToDescriptions[branchLabels[0]], labelsToColours[branchLabels[0]]))
+			}
+			err := c.GitHub.AddLabels(org, repo, number, branchLabels)
+			if err != nil {
+				c.Logger.WithError(err).Errorf("failed to add branch labels on PR #%d", number)
+				return
+			}
+		}
+	}
 
 	var comments []*github.IssueComment
 	labelToAdd := determineReleaseNoteLabel(pr.GetPullRequest().GetBody(), prLabels)
@@ -109,7 +145,6 @@ func handleReleaseNotesPR(c *Context, pr *github.PullRequestEvent) {
 	if err != nil {
 		c.Logger.WithError(err)
 	}
-
 }
 
 func handleReleaseNotesComment(c *Context, ic *github.IssueCommentEvent) error {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -63,6 +63,18 @@ func (g *GHClient) CreateComment(org, repo string, number int, comment string) {
 	}
 }
 
+// CreateLabel creates a GitHub label to a specific repository if it doesn't exist.
+func (g *GHClient) CreateLabel(org, repo string, label github.Label) error {
+	g.logger.WithField("labels", label).Debug("Creating GitHub label")
+	_, _, err := g.GitHubClient.Issues.CreateLabel(context.Background(), org, repo, &label)
+	if err != nil {
+		g.logger.WithError(err).Debug("Failed to create GitHub label")
+		return err
+	}
+
+	return nil
+}
+
 // AddLabels adds a GitHub label to a specific issue/pull request.
 func (g *GHClient) AddLabels(org, repo string, number int, labels []string) error {
 	g.logger.WithField("labels", labels).Debug("Setting GitHub label")

--- a/internal/utils/github_utils.go
+++ b/internal/utils/github_utils.go
@@ -37,7 +37,7 @@ func NormLogin(login string) string {
 	return strings.TrimPrefix(strings.ToLower(login), "@")
 }
 
-// LabelsSet create a label set based on the gihub labels to make easier the manipulation
+// LabelsSet create a label set based on the github labels to make easier the manipulation
 func LabelsSet(labels []*github.Label) sets.String {
 	prLabels := sets.String{}
 	for _, label := range labels {


### PR DESCRIPTION
If this commit applied chewbacca will add specific labels on specific branch names
This follows Mattermost Cloud SRE team's branch naming conventions.
Also if a label does not exist on the repo it is going to be created.

Issue: MM-35692


#### Summary
Add labels on specific branch names

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-35692

#### Release Note


```release-note
Adds labels to PR on specific branch names.
```
